### PR TITLE
Update broken link

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -2,7 +2,7 @@
 layout: default
 title: Endless Sky Plugin List
 ---
-<p>A proof-of-concept plugin sharing site is available at <a href="https://codedraken.github.io/ES-Mod-Share/">codedraken.github.io/ES-Mod-Share</a>.</p>
+<p>A proof-of-concept plugin sharing site is available at <a href="https://opengamemods-group.github.io/ES-Mod-Share/">opengamemods-group.github.io/ES-Mod-Share/</a>.</p>
 <p>Instructions for <a href="https://github.com/endless-sky/endless-sky/wiki/CreatingPlugins">creating plugins</a> are on the wiki.</p>
 <p>Eventually, it will be possible to download and install plugins from within the game. To support both that and a more detailed plugin listing here on the website, each plugin will need to provide, at minimum:</p>
 <ul>


### PR DESCRIPTION
I moved the proof of concept mod sharing site so the link needs to be updated. It is deprecated and I'm probably going make a real site called "Open Game Mods" for *open source* mods, guides, etc.

If you have any use for the proof of concept site then I can transfer ownership to you. I heard you guys were working on an in-game mod manager, so you probably don't need it.