### PR TITLE
Document indentation requirements on blank lines and trailing whitespace.

### DIFF
--- a/styleguide/styleguide.xml
+++ b/styleguide/styleguide.xml
@@ -627,7 +627,8 @@ x = temp;
 <STYLEPOINT title="Indentation in blank lines">
 <SUMMARY>Blank lines should be indented to the same level as the code directly above and below it.</SUMMARY>
 <BODY>
-<p>This should help developers with editors that take indentation for new code from the line above.</p>
+<p>The indentation should be such that a new expression could be entered on the otherwise-empty line and immediately be aligned with other expressions having the same block scope.
+<p>This should help developers with editors that take indentation for new code from the line above, or do not have automatic indentation detection.</p>
 </BODY>
 </STYLEPOINT>
 

--- a/styleguide/styleguide.xml
+++ b/styleguide/styleguide.xml
@@ -624,6 +624,20 @@ x = temp;
 </BODY>
 </STYLEPOINT>
 
+<STYLEPOINT title="Indentation in blank lines">
+<SUMMARY>Blank lines should be indented to the same level as the code directly above and below it.</SUMMARY>
+<BODY>
+<p>This should help developers with editors that take indentation for new code from the line above.</p>
+</BODY>
+</STYLEPOINT>
+
+<STYLEPOINT title="No trailing whitespace">
+<SUMMARY>Lines with code or comments should not have trailing whitespace.</SUMMARY>
+<BODY>
+<p>Trailing whitespace looks very unprofessional and should be avoided (except where required on blank lines within a code-block).</p>
+</BODY>
+</STYLEPOINT>
+
 <STYLEPOINT title="One expression per line">
 <SUMMARY>Do not put multiple expression on the same line.</SUMMARY>
 <BODY>

--- a/styleguide/styleguide.xml
+++ b/styleguide/styleguide.xml
@@ -632,13 +632,6 @@ x = temp;
 </BODY>
 </STYLEPOINT>
 
-<STYLEPOINT title="No trailing whitespace">
-<SUMMARY>Lines with code or comments should not have trailing whitespace.</SUMMARY>
-<BODY>
-<p>Trailing whitespace looks very unprofessional and should be avoided (except where required on blank lines within a code-block).</p>
-</BODY>
-</STYLEPOINT>
-
 <STYLEPOINT title="One expression per line">
 <SUMMARY>Do not put multiple expression on the same line.</SUMMARY>
 <BODY>


### PR DESCRIPTION
The Endless Sky codebase has a quite unique requirement regarding white-space on blank lines. Most new contributors are not familiar with those whitespace requirements and will get their first commits rejected on whitespace issues.

This change explicitly documents the whitespace requirements to make sure they match the expectations of the Endless Sky author and code maintainers.