### PR TITLE
Add discord to the navigation links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -128,7 +128,7 @@
 	<a href="https://github.com/endless-sky/endless-sky/issues">Bug Reports</a><br />
 	<a href="https://github.com/endless-sky/endless-sky-editor/releases">Map Editor</a><br />
 	<a href="https://groups.google.com/forum/#!forum/endless-sky">Forum</a><br />
-	<a href="https://discord.gg/ZeuASSx">Discord</a><br />
+	<a href="https://discord.gg/ZeuASSx">Endless Sky Community Discord</a><br />
 </div>
 
 <div class="doodad">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -128,6 +128,7 @@
 	<a href="https://github.com/endless-sky/endless-sky/issues">Bug Reports</a><br />
 	<a href="https://github.com/endless-sky/endless-sky-editor/releases">Map Editor</a><br />
 	<a href="https://groups.google.com/forum/#!forum/endless-sky">Forum</a><br />
+	<a href="https://discord.gg/ZeuASSx">Discord</a><br />
 </div>
 
 <div class="doodad">


### PR DESCRIPTION
Adding in a new link.
Issue #23 This points people to where current discussion is happening.