### PR TITLE
fix(UI): Revert "Add discord to the navigation links"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -128,7 +128,6 @@
 	<a href="https://github.com/endless-sky/endless-sky/issues">Bug Reports</a><br />
 	<a href="https://github.com/endless-sky/endless-sky-editor/releases">Map Editor</a><br />
 	<a href="https://groups.google.com/forum/#!forum/endless-sky">Forum</a><br />
-	<a href="https://discord.gg/ZeuASSx">Endless Sky Community Discord</a><br />
 </div>
 
 <div class="doodad">


### PR DESCRIPTION
Reverts endless-sky/endless-sky.github.io#24
![image](https://user-images.githubusercontent.com/20871346/109523371-eadbcb00-7a74-11eb-94fe-ec55406de604.png)
