### PR TITLE
Various improvements to the website.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .jekyll-cache/
 .jekyll-metadata/
+_site

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,7 +54,7 @@
 </div>
 
 <div class="nav-image">
-	<svg class="shadowed" xmlns="http://www.w3.org/2000/svg" version="1.1" width="200" height="400">
+	<svg class="shadowed" xmlns="http://www.w3.org/2000/svg" version="1.1" width="200" height="600">
 		<g stroke="#000" stroke-width="1.2" fill="none">
 			<g stroke-opacity=".27">
 				<path d="m40 360v1l-2 2h-13l-3-3"/>
@@ -113,6 +113,7 @@
 		<g stroke="#333" stroke-width="1.2" fill="#eee">
 			<path d="m-10 170h160v150l-40 40h-120v-190z"/>
 			<path d="m-10 20h160v110l-20 20h-140v-130z"/>
+			<path d="m-10 380h160v80l-20 20h-140v-130z"/>
 		</g>
 	</svg>
 </div>
@@ -122,12 +123,16 @@
 	<a href="/screenshots.html">Screenshots</a><br />
 	<a href="/plugins.html">Plugins</a><br />
 	&nbsp;<br />
-	<a href="https://github.com/endless-sky/endless-sky/releases">Downloads</a><br />
+	<a href="https://github.com/endless-sky/endless-sky/releases/latest">Downloads</a><br />
 	<a href="https://github.com/endless-sky/endless-sky/wiki/PlayersManual">Manual</a><br />
 	<a href="https://github.com/endless-sky/endless-sky/wiki">Wiki</a><br />
 	<a href="https://github.com/endless-sky/endless-sky/issues">Bug Reports</a><br />
 	<a href="https://github.com/endless-sky/endless-sky-editor/releases">Map Editor</a><br />
-	<a href="https://groups.google.com/forum/#!forum/endless-sky">Forum</a><br />
+	<a href="https://github.com/endless-sky/endless-sky/discussions">Discussions</a><br />
+	&nbsp;<br />
+	<a href="https://github.com/endless-sky/endless-sky">GitHub</a><br />
+	<a href="https://discord.gg/ZeuASSx">Discord</a><br />
+	<a href="https://store.steampowered.com/app/404410/Endless_Sky/">Steam</a><br />
 </div>
 
 <div class="doodad">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title: Endless Sky, an open source space trading and combat game.
 <h2 class="header">A galaxy lies open for you to explore.</h2>
 
 <p>Endless Sky is a 2D space trading and combat game similar to the classic Escape Velocity series. Explore other star systems. Earn money by trading, carrying passengers, or completing missions. Use your earnings to buy a better ship or to upgrade the weapons and engines on your current one. Blow up pirates. Take sides in a civil war. Or leave human space behind and hope to find friendly aliens whose culture is more civilized than your own.</p>
-<p><a href="https://github.com/endless-sky/endless-sky/releases">Downloads</a> are available for Mac OS X and Windows, and many Linux distributions are also supported. Endless Sky is free and open source, the product of a growing community of developers and content creators.</p>
+<p><a href="https://github.com/endless-sky/endless-sky/releases/latest">Downloads</a> are available for Windows, Mac OS, and Linux. Endless Sky is free and open source, the product of a growing community of developers and content creators.</p>
 
 <img class="intro-image" src="/images/introduction/starting-ships.jpg" title="The three ships you can choose between at the start of the game." />
 

--- a/plugin-manifest-gen.html
+++ b/plugin-manifest-gen.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="https://unpkg.com/@highlightjs/cdn-assets@11.5.1/highlight.min.js"></script>
+    <script src="https://unpkg.com/@highlightjs/cdn-assets@11.5.1/languages/yaml.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@11.5.1/styles/stackoverflow-light.min.css">
+    <style>
+        @import url(https://unpkg.com/firacode@6.2.0/distr/fira_code.css);
+
+        .splitter-half {
+            width: 50%;
+        }
+
+        #splitter-left {
+            float: left;
+        }
+
+        #splitter-right {
+            float: right;
+        }
+
+        .splitter-inner {
+            padding: 20px;
+        }
+
+        .form-section {
+            padding-top: 10px;
+            padding-bottom: 10px;
+        }
+
+        form h3 {
+            margin-top: 0px;
+            margin-bottom: 5px;
+        }
+
+        .status {
+            font-size: small;
+            padding-left: 5x;
+            text-align: right;
+        }
+
+        .success {
+            color: green;
+        }
+
+        .error {
+            color: red;
+        }
+
+        .warning {
+            color: orangered;
+        }
+
+        .hint {
+            font-size: small;
+            opacity: 80%;
+            padding: 5px;
+        }
+
+        form input[type=text] {
+            margin: 5px;
+            padding: 3px;
+            width: 100%;
+            border-width: 0px 0px 2px 0px;
+            border-color: gray;
+            font-family: 'Fira Code', monospace;
+            outline: none;
+        }
+
+        form textarea {
+            margin: 5px;
+            padding: 5px;
+            width: 100%;
+            border-width: 1px 1px 2px 1px;
+            border-color: gray;
+            font-family: 'Fira Code', monospace;
+            font-size: smaller;
+            outline: none;
+        }
+
+        form input:focus-visible {
+            border-color: #333;
+        }
+
+        form fieldset {
+            opacity: 90%;
+            margin: 10px;
+        }
+
+        form {
+            display: flex;
+            flex-direction: column;
+            align-items: stretch;
+        }
+
+        #output {
+            font-family: 'Fira Code', monospace;
+            font-size: smaller;
+            line-height: 2;
+            white-space: pre-wrap;
+        }
+
+        #copy-output-container {
+            display: flex;
+            justify-content: flex-end;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="splitter-half" id="splitter-left">
+        <form class="splitter-inner">
+
+            <div class="form-section">
+                <h3>Basics:</h3>
+
+                <div class="hint">The name of your Plug-In.</div>
+                <input name="name" id="name" type="text" placeholder="My Awesome Plug-In">
+
+                <div class="hint">One or more authors.</div>
+                <input name="authors" id="authors" type="text" placeholder="Michael Zahniser & Contributors">
+            </div>
+
+            <div class="form-section">
+                <h3>Homepage:</h3>
+
+                <div class="hint">The homepage of your Plug-In. If you don't have a dedicated homepage, it is common to
+                    use your Github Repository.</div>
+                <input name="homepage" id="homepage" type="text"
+                    placeholder="https://github.com/endless-sky/endless-sky-high-dpi/">
+
+                <div class="hint">Your repository's git URL. Leave blank if you used your Github repository as homepage,
+                    or if your homepage redirects to a git URL.</div>
+                <input name="update-url" id="update-url" type="text"
+                    placeholder="https://github.com/endless-sky/endless-sky-high-dpi.git">
+            </div>
+
+            <div class="form-section">
+                <h3>License:</h3>
+                <div class="hint">
+                    A License Identifier as found on <a href="https://spdx.org/licenses/">SPDX</a>. Common
+                    Licenses are <code>GPL-3.0-or-later</code> (used by Endless Sky) or <code>CC-BY-SA-4.0</code> (used
+                    by
+                    the High DPI plugin).
+                </div>
+                <input name="license" id="license" type="text" placeholder="CC-BY-SA-4.0">
+                <div class="status warning" id="license-status">Loading License List...</div>
+            </div>
+
+            <div class="form-section">
+                <h3>Version:</h3>
+
+                <fieldset>
+                    <legend>How do you want to version your Plugin?</legend>
+                    <input value="tag" name="version-type" id="version-type-tag" type="radio" checked>
+                    <label for="version-type-tag">Github Release / git tag</label>
+                    <br>
+                    <input value="commit" name="version-type" id="version-type-commit" type="radio">
+                    <label for="version-type-commit">Commit</label>
+                </fieldset>
+
+                <div class="hint">
+                    The latest version of your Plug-In.
+                </div>
+                <input name="version" id="version" type="text" placeholder="v0.9.14">
+                <div class="status error" id="license-status"></div>
+            </div>
+
+            <div class="form-section">
+                <h3>Descriptions:</h3>
+
+                <div class="hint">A short description. Ideally less than 150 characters, must be less than 200.</div>
+                <textarea name="short-description" id="short-description" type="textbox"
+                    placeholder="High-DPI graphics for Endless Sky." rows="1"></textarea>
+                <div class="status" id="short-description-status">0/200</div>
+
+                <div class="hint">A description of arbitrary length.</div>
+                <textarea name="description" id="description" type="textbox" rows="2"
+                    placeholder="This plugin contains double resolution graphics, which are only used if you have a high-dpi monitor or if you set the zoom level above 100%. This will roughly double the amount of memory used by the game."></textarea>
+            </div>
+
+            <div class="form-section">
+                <h3>Download URLs:</h3>
+
+                <div class="hint">A URL to a direct .zip download. It's important that this URL be "versioned", i.e.
+                    contains your version, so it may only point to a download for this release and no other.</div>
+                <input name="download-url" id="download-url" type="text"
+                    placeholder="https://github.com/endless-sky/endless-sky-high-dpi/archive/refs/tags/v0.9.14.zip">
+                <div class="status" id="download-url-status"></div>
+
+                <br>
+                <div class="hint">A URL to your plugin's icon, if any. Make sure this URL is versioned, just like the
+                    one above.</div>
+                <input name="icon-url" id="icon-url" type="text"
+                    placeholder="https://github.com/endless-sky/endless-sky-high-dpi/raw/v0.9.14/icon.png">
+                <div class="status" id="icon-url-status"></div>
+            </div>
+
+
+        </form>
+    </div>
+    <div class="splitter-half" id="splitter-right">
+        <div class="splitter-inner">
+            <h3>Output:</h3>
+            <pre>
+                <code id="output" class="language-yaml"></code>
+            </pre>
+            <div id="copy-output-container">
+                <button id="copy-output">Copy to Clipboard</button>
+            </div>
+        </div>
+    </div>
+</body>
+<script>
+    document.querySelector("#copy-output").addEventListener("click", event => {
+        let text = document.querySelector("#output").textContent;
+        navigator.clipboard.writeText(text);
+    });
+
+    fetch('https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')
+        .then(response => {
+            if (response.status == 200) {
+                return response.json();
+            }
+            else {
+                return { "licenses": [] };
+            }
+        })
+        .then(json => json.licenses.filter(l => !l.isDeprecatedLicenseId))
+        .then(list => licenses = list)
+        .then(() => generate());
+
+    let form = document.querySelector("form");
+    let nameInput = form.querySelector("#name");
+    let authorsInput = form.querySelector("#authors");
+    let homepageInput = form.querySelector("#homepage");
+    let updateUrlInput = form.querySelector("#update-url");
+    let licenseInput = form.querySelector("#license");
+    let isTagInput = form.querySelector("#version-type-tag");
+    let versionInput = form.querySelector("#version");
+    let shortDescInput = form.querySelector("#short-description");
+    let descInput = form.querySelector("#description");
+    let downloadUrlInput = form.querySelector("#download-url");
+    let iconUrlInput = form.querySelector("#icon-url");
+
+    const generate = function () {
+        let isTag = isTagInput.checked;
+        if (isTag) {
+            versionInput.placeholder = "v0.9.14";
+            downloadUrlInput.placeholder = "https://github.com/endless-sky/endless-sky-high-dpi/archive/refs/tags/v0.9.14.zip";
+            iconUrlInput.placeholder = "https://github.com/endless-sky/endless-sky-high-dpi/raw/v0.9.14/icon.png";
+        }
+        else {
+            versionInput.placeholder = "4a31a851735655e1abdbfd7ff75e139565dcde8d";
+            downloadUrlInput.placeholder = "https://github.com/endless-sky/endless-sky-high-dpi/archive/4a31a851735655e1abdbfd7ff75e139565dcde8d.zip";
+            iconUrlInput.placeholder = "https://github.com/endless-sky/endless-sky-high-dpi/raw/4a31a851735655e1abdbfd7ff75e139565dcde8d/icon.png";
+        }
+
+        let name = nameInput.value || nameInput.placeholder;
+        let authors = authorsInput.value || authorsInput.placeholder;
+        let homepage = homepageInput.value || homepageInput.placeholder;
+        let updateUrl = updateUrlInput.value || null; // optional
+        let license = licenseInput.value || licenseInput.placeholder;
+        let version = versionInput.value || versionInput.placeholder;
+        let shortDesc = shortDescInput.value || shortDescInput.placeholder;
+        let desc = descInput.value || descInput.placeholder;
+        let downloadUrl = downloadUrlInput.value || downloadUrlInput.placeholder;
+        let iconUrl = iconUrlInput.value || null; // optional
+
+        let licenseStatus = form.querySelector("#license-status");
+        if (typeof licenses !== "undefined" && licenses.length == 0) {
+            licenseStatus.textContent = "License List could not be loaded - please report this error!";
+            licenseStatus.setAttribute("class", "status warning");
+        } else if (typeof licenses !== "undefined") {
+            let spdx = licenses.find(l => l.licenseId == license);
+            if (spdx) {
+                licenseStatus.textContent = spdx.name;
+                licenseStatus.setAttribute("class", "status success");
+            }
+            else {
+                licenseStatus.textContent = "Unknown License";
+                licenseStatus.setAttribute("class", "status error");
+            }
+        }
+
+        let shortDescStatus = form.querySelector("#short-description-status");
+        let shortDescLength = shortDescInput.value.length;
+        shortDescStatus.textContent = `${shortDescLength}/200`
+        if (shortDescLength > 200) {
+            shortDescStatus.setAttribute("class", "status error");
+        }
+        else if (shortDescLength > 150) {
+            shortDescStatus.setAttribute("class", "status warning");
+        }
+        else {
+            shortDescStatus.setAttribute("class", "status");
+        }
+
+        let downloadUrlStatus = form.querySelector("#download-url-status");
+        let autoupdateDownloadUrl = null;
+        if (downloadUrl.includes(version)) {
+            downloadUrlStatus.textContent = `contains "${version}"`
+            downloadUrlStatus.setAttribute("class", "status success");
+            autoupdateDownloadUrl = downloadUrl.replace(version, "$version");
+        }
+        else {
+            downloadUrlStatus.textContent = "No version string in this URL, are you it is unique for each release?";
+            downloadUrlStatus.setAttribute("class", "status warning");
+        }
+
+        let iconUrlStatus = form.querySelector("#icon-url-status");
+        let autoupdateIconUrl = null;
+        if (iconUrl && iconUrl.includes(version)) {
+            iconUrlStatus.textContent = `contains "${version}"`
+            iconUrlStatus.setAttribute("class", "status success");
+            autoupdateIconUrl = iconUrl.replace(version, "$version");
+        }
+        else if (iconUrl) {
+            iconUrlStatus.textContent = "No version string in this URL, are you it is unique for each release?";
+            iconUrlStatus.setAttribute("class", "status warning");
+        }
+        else {
+            iconUrlStatus.textContent = "\u00a0"; // &nbsp
+        }
+
+        let output = `name: ${name}
+authors: ${authors}
+homepage: ${homepage}
+license: ${license}
+version: ${version}
+shortDescription: ${shortDesc}
+description: ${desc}
+url: ${downloadUrl}
+`;
+
+        if (iconUrl) {
+            output += `iconUrl: ${iconUrl}
+`
+        }
+
+        if (autoupdateDownloadUrl) {
+            output += `autoupdate:
+`
+            if (isTag) {
+                output += `  type: tag
+`
+            }
+            else {
+                output += `  type: commit
+`
+            }
+            if (updateUrl) {
+                output += `  updateUrl: ${updateUrl}
+`
+            }
+            output += `  url: ${autoupdateDownloadUrl}
+`
+            if (autoupdateIconUrl) {
+                output += `  iconUrl: ${autoupdateIconUrl}
+`
+            }
+        }
+
+        document.querySelector("#output").replaceChildren(document.createTextNode(output));
+
+        hljs.highlightAll();
+    }
+
+    form.addEventListener("input", event => generate());
+    generate();
+</script>
+
+</html>

--- a/plugin-manifest-gen.html
+++ b/plugin-manifest-gen.html
@@ -115,35 +115,35 @@
             <div class="form-section">
                 <h3>Basics:</h3>
 
-                <div class="hint">The name of your Plug-In.</div>
+                <label class="hint" for="name">The name of your Plug-In.</label>
                 <input name="name" id="name" type="text" placeholder="My Awesome Plug-In">
 
-                <div class="hint">One or more authors.</div>
+                <label class="hint" for="authors">One or more authors.</label>
                 <input name="authors" id="authors" type="text" placeholder="Michael Zahniser & Contributors">
             </div>
 
             <div class="form-section">
                 <h3>Homepage:</h3>
 
-                <div class="hint">The homepage of your Plug-In. If you don't have a dedicated homepage, it is common to
-                    use your Github Repository.</div>
+                <label class="hint" for="homepage">The homepage of your Plug-In. If you don't have a dedicated homepage, it is common to
+                    use your Github Repository.</label>
                 <input name="homepage" id="homepage" type="text"
                     placeholder="https://github.com/endless-sky/endless-sky-high-dpi/">
 
-                <div class="hint">Your repository's git URL. Leave blank if you used your Github repository as homepage,
-                    or if your homepage redirects to a git URL.</div>
+                <label class="hint" for="update-url">Your repository's git URL. Leave blank if you used your Github repository as homepage,
+                    or if your homepage redirects to a git URL.</label>
                 <input name="update-url" id="update-url" type="text"
                     placeholder="https://github.com/endless-sky/endless-sky-high-dpi.git">
             </div>
 
             <div class="form-section">
                 <h3>License:</h3>
-                <div class="hint">
+                <label class="hint" for="license">
                     A License Identifier as found on <a href="https://spdx.org/licenses/">SPDX</a>. Common
                     Licenses are <code>GPL-3.0-or-later</code> (used by Endless Sky) or <code>CC-BY-SA-4.0</code> (used
                     by
                     the High DPI plugin).
-                </div>
+                </label>
                 <input name="license" id="license" type="text" placeholder="CC-BY-SA-4.0">
                 <div class="status warning" id="license-status">Loading License List...</div>
             </div>
@@ -160,9 +160,9 @@
                     <label for="version-type-commit">Commit</label>
                 </fieldset>
 
-                <div class="hint">
+                <label class="hint" for="version">
                     The latest version of your Plug-In.
-                </div>
+                </label>
                 <input name="version" id="version" type="text" placeholder="v0.9.14">
                 <div class="status error" id="license-status"></div>
             </div>
@@ -170,12 +170,12 @@
             <div class="form-section">
                 <h3>Descriptions:</h3>
 
-                <div class="hint">A short description. Ideally less than 150 characters, must be less than 200.</div>
+                <label class="hint" for="short-description">A short description. Ideally less than 150 characters, must be less than 200.</label>
                 <textarea name="short-description" id="short-description" type="textbox"
                     placeholder="High-DPI graphics for Endless Sky." rows="1"></textarea>
                 <div class="status" id="short-description-status">0/200</div>
 
-                <div class="hint">A description of arbitrary length.</div>
+                <label class="hint" for="description">A description of arbitrary length.</label>
                 <textarea name="description" id="description" type="textbox" rows="2"
                     placeholder="This plugin contains double resolution graphics, which are only used if you have a high-dpi monitor or if you set the zoom level above 100%. This will roughly double the amount of memory used by the game."></textarea>
             </div>
@@ -183,15 +183,15 @@
             <div class="form-section">
                 <h3>Download URLs:</h3>
 
-                <div class="hint">A URL to a direct .zip download. It's important that this URL be "versioned", i.e.
-                    contains your version, so it may only point to a download for this release and no other.</div>
+                <label class="hint" for="download-url">A URL to a direct .zip download. It's important that this URL be "versioned", i.e.
+                    contains your version, so it may only point to a download for this release and no other.</label>
                 <input name="download-url" id="download-url" type="text"
                     placeholder="https://github.com/endless-sky/endless-sky-high-dpi/archive/refs/tags/v0.9.14.zip">
                 <div class="status" id="download-url-status"></div>
 
                 <br>
-                <div class="hint">A URL to your plugin's icon, if any. Make sure this URL is versioned, just like the
-                    one above.</div>
+                <label class="hint" for="icon-url">A URL to your plugin's icon, if any. Make sure this URL is versioned, just like the
+                    one above.</label>
                 <input name="icon-url" id="icon-url" type="text"
                     placeholder="https://github.com/endless-sky/endless-sky-high-dpi/raw/v0.9.14/icon.png">
                 <div class="status" id="icon-url-status"></div>
@@ -218,6 +218,7 @@
         navigator.clipboard.writeText(text);
     });
 
+	let licenses = [];
     fetch('https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json')
         .then(response => {
             if (response.status == 200) {

--- a/plugins.html
+++ b/plugins.html
@@ -8,18 +8,10 @@ title: Endless Sky Plugin List
 <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.25/js/jquery.dataTables.js"></script>
 <link rel="stylesheet" type="text/css" href="{{ 'plugins.css' | relative_url }}">
 
-<p>Instructions for <a href="https://github.com/endless-sky/endless-sky/wiki/CreatingPlugins">creating plugins</a> are on the wiki.</p>
-<p>Eventually, it will be possible to download and install plugins from within the game. To support both that and a more detailed plugin listing here on the website, each plugin will need to provide, at minimum:</p>
-<ul>
-	<li><p>A title, author name, and short description.</p></li>
-	<li><p>A longer description to be shown if the user clicks on a particular plugin in the gallery to view more information.</p></li>
-	<li><p>A list of tags to be used when filtering the plugin list.</p></li>
-	<li><p>A "cover image" representing the mod. These will all be required to be a certain size, but I haven't decided yet what the size should be.</p></li>
-	<li><p>One or more screenshots of the plugin in action. All screenshots should have a 16:9 aspect ratio, e.g. 1280&times;720 or 1920&times;1080. (You can edit your preferences file to set the window size to an exact value.)</p></li>
-	<li><p>A download link to a zip file. Ideally, the download link changes every time a new version of the mod is released, both so that older versions remain accessible and so that the game client will be able to tell from the path when a new version is available.</p></li>
-</ul>
-<p>The preferred way to host a plugin is to create a GitHub repository for it. The "gh-pages" branch of the repository should contain the cover image and screenshots, and may also host a web page providing more information about the plugin. The default branch should contain the plugin itself. New downloads can be created just by tagging a release in the default branch.</p>
-<br>
+<h2 class="header">Plugin List</h2>
+
+<p>A list of community created plugins. If you would like to add your plugin, follow the instructions on the
+<a href="https://github.com/endless-sky/endless-sky/wiki/PluginRepository">wiki</a>.</p>
 
 <div id=plugin-list><p>Loading plugins...</p></div>
 
@@ -48,6 +40,7 @@ function init() {
 			$(table).DataTable({
 				columnDefs: colOptions,
 				order: [[1, 'asc']],
+				pageLength: 50,
 			});
 		})
 		.catch((err) => {

--- a/screenshots.html
+++ b/screenshots.html
@@ -7,22 +7,6 @@ title: Endless Sky screenshots.
 {% for image in site.screenshots %}
 	<img class="gallery-thumb" onclick="openLightbox(this)" src="{{ image.src }}" title="{{ image.title }}" alt="{{ image.alt }}" />
 {% endfor %}
-	<div id="lightbox-back" onclick="closeLightbox()">
-		<div id="lightbox">
-			<img id="lightbox-image" />
-			<div id="lightbox-previous" onclick="previousLightbox(event);">
-				<img id="lightbox-previous-arrow" src="/images/lightbox-previous.svg" />
-			</div>
-			<div id="lightbox-next" onclick="nextLightbox(event);">
-				<img id="lightbox-next-arrow" src="/images/lightbox-next.svg" />
-			</div>
-		</div>
-		<br />
-		<div id="lightbox-caption-back">
-			<p id="lightbox-title"></p>
-			<p id="lightbox-caption"></p>
-		</div>
-	</div>
 </div>
 
 <h2 class="header">Artwork / Wallpapers</h2>
@@ -32,3 +16,19 @@ title: Endless Sky screenshots.
 {% endfor %}
 </div>
 
+<div id="lightbox-back" onclick="closeLightbox()">
+	<div id="lightbox">
+		<img id="lightbox-image" />
+		<div id="lightbox-previous" onclick="previousLightbox(event);">
+			<img id="lightbox-previous-arrow" src="/images/lightbox-previous.svg" />
+		</div>
+		<div id="lightbox-next" onclick="nextLightbox(event);">
+			<img id="lightbox-next-arrow" src="/images/lightbox-next.svg" />
+		</div>
+	</div>
+	<br />
+	<div id="lightbox-caption-back">
+		<p id="lightbox-title"></p>
+		<p id="lightbox-caption"></p>
+	</div>
+</div>


### PR DESCRIPTION
This PR changes the following:

- Adds the jekyll generated site to .gitignore
- Adds a new panel on the sidebar that links to Github, Steam and the Discord.
- The Downloads link now points to the latest release instead of the general releases page.
- Adds a helpful website to generate a plugin manifest file for the repo (courtesy of @MCOfficer, all credit goes to him)
- Fixes the render thumbnails being drawn over the fullscreen gallery image.
- Removed all the irrelevant text on the plugins page (I plan on adding that information on the ES Wiki for creating plugins)
- Changed the default amount of plugins shown to 50.
- Added two sentences to the plugins page that links to the ES Wiki on how to add your plugin to the repo (I will publish that page if this PR gets merged)
- Added a title to the plugins page.
- Changed the Forums link to the Github Discussions link (since the Google Forums are dead).

That's it!

## Screenshots

![image](https://user-images.githubusercontent.com/85879619/176518318-002771d1-8e32-49e5-b630-8b4c454fa51d.png)

![image](https://user-images.githubusercontent.com/85879619/176518397-8bd947ff-bf6d-487d-a2ff-142c54b1290b.png)
