### PR TITLE
fix: plugin list truncates long semver-ish version

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -121,7 +121,10 @@ function init() {
 		link.href = homepage;
 		link.text = name;
 		link.classList.add('plugin-name');
-		return [link, document.createElement('br'), `Version: ${version.substring(0, 7)}`];
+		if (version.length == 40) {
+			version = version.substring(0, 7);
+		}
+		return [link, document.createElement('br'), `Version: ${version}`];
 	}
 	function createByline({ author, authors }) {
 		if (author) return author;


### PR DESCRIPTION
Currently the plug-in list truncates versions to 7 characters, which breaks longer versions like the ones Midnight Plugins use (` 0.9.14.16.13`).

This PR only truncates versions only if they're exactly 40 characters, the length of a commit hash.