### PR TITLE
fix

### DIFF
--- a/styleguide/styleguide.xml
+++ b/styleguide/styleguide.xml
@@ -86,7 +86,7 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with
-this program. If not, see <https://www.gnu.org/licenses/>.
+this program. If not, see <![CDATA[<a href="https://www.gnu.org/licenses/">&gthttps://www.gnu.org/licenses/&lt</a>]]>.
 */
 </CODE_SNIPPET>
 </SUMMARY>


### PR DESCRIPTION
I _think_ this fixes the bug in the C++ style guide, caused by an unformatted hyperlink. I'm not 100% sure the new link works, but the XML file is properly formatted now.

@quyykk Please check this