### PR TITLE
Add GOG link to sidebar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -133,7 +133,7 @@
 	<a href="https://github.com/endless-sky/endless-sky">GitHub</a><br />
 	<a href="https://discord.gg/ZeuASSx">Discord</a><br />
 	<a href="https://store.steampowered.com/app/404410/Endless_Sky/">Steam</a><br />
-	<a href="https://www.gog.com/en/game/endless_sky">GOG</a><br />
+	<a href="https://www.gog.com/game/endless_sky">GOG</a><br />
 </div>
 
 <div class="doodad">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -113,7 +113,7 @@
 		<g stroke="#333" stroke-width="1.2" fill="#eee">
 			<path d="m-10 170h160v150l-40 40h-120v-190z"/>
 			<path d="m-10 20h160v110l-20 20h-140v-130z"/>
-			<path d="m-10 380h160v80l-20 20h-140v-130z"/>
+			<path d="m-10 380h160v100l-20 30h-140v-130z"/>
 		</g>
 	</svg>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -113,7 +113,7 @@
 		<g stroke="#333" stroke-width="1.2" fill="#eee">
 			<path d="m-10 170h160v150l-40 40h-120v-190z"/>
 			<path d="m-10 20h160v110l-20 20h-140v-130z"/>
-			<path d="m-10 380h160v100l-20 30h-140v-130z"/>
+			<path d="m-10 380h160v110l-20 20h-140v-130z"/>
 		</g>
 	</svg>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -133,6 +133,7 @@
 	<a href="https://github.com/endless-sky/endless-sky">GitHub</a><br />
 	<a href="https://discord.gg/ZeuASSx">Discord</a><br />
 	<a href="https://store.steampowered.com/app/404410/Endless_Sky/">Steam</a><br />
+	<a href="https://www.gog.com/en/game/endless_sky">GOG</a><br />
 </div>
 
 <div class="doodad">


### PR DESCRIPTION
Since we have a GOG page and Steam's listed in the sidebar, I thought it should go there.

<img width="1440" alt="Screenshot 2024-02-07 at 10 12 05 PM" src="https://github.com/endless-sky/endless-sky.github.io/assets/115441627/79b43c0c-e58f-479d-af48-a2493dbe5caa">
