### PR TITLE
Fix type in 0.10.8 blog post: unstable -> stable

### DIFF
--- a/_posts/2024-06-22-stable-release-0.10.8.md
+++ b/_posts/2024-06-22-stable-release-0.10.8.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Unstable release 0.10.8
+title: Stable release 0.10.8
 author: Amazinite
 ---
 


### PR DESCRIPTION
The post title says "unstable" but this was a stable release.